### PR TITLE
V3.0.2

### DIFF
--- a/file_checker_exec/pom.xml
+++ b/file_checker_exec/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.ifremer</groupId>
 	<artifactId>file_checker_exec</artifactId>
-	<version>3.0.1</version>
+	<version>3.0.2</version>
 
 	<name>Argo NetCDF file format checker</name>
 

--- a/file_checker_exec/src/main/java/fr/coriolis/checker/specs/ArgoConfigTechParam.java
+++ b/file_checker_exec/src/main/java/fr/coriolis/checker/specs/ArgoConfigTechParam.java
@@ -350,15 +350,6 @@ public class ArgoConfigTechParam {
 			}
 		}
 
-		if (deprecatedList != null) {
-			if (deprecatedList.contains(name)) {
-				match = new ArgoConfigTechParamMatch(name, true);
-
-				log.debug("findParam: '{}': deprecated literal match", name);
-				return match;
-			}
-		}
-
 		// ..did NOT match one of the literal strings
 		// ..check for a regex match
 
@@ -370,6 +361,15 @@ public class ArgoConfigTechParam {
 			if (match != null) {
 				match.isDeprecated = false;
 				log.debug("findParam: '{}': active regex match '{}'", name, match.match);
+				return match;
+			}
+		}
+
+		if (deprecatedList != null) {
+			if (deprecatedList.contains(name)) {
+				match = new ArgoConfigTechParamMatch(name, true);
+
+				log.debug("findParam: '{}': deprecated literal match", name);
 				return match;
 			}
 		}

--- a/file_checker_exec/src/main/java/fr/coriolis/checker/validators/ArgoMetadataFileValidator.java
+++ b/file_checker_exec/src/main/java/fr/coriolis/checker/validators/ArgoMetadataFileValidator.java
@@ -151,7 +151,10 @@ public class ArgoMetadataFileValidator extends ArgoFileValidator {
 			validateOptionalParams();
 			validateConfigMission();
 			validateConfigParams();
-			validateBattery();
+			// 04/2026 V3.0.2 : Battery parameters's checks are deactivated for the moment
+			// as majority of files was not compliants. More time is given to DACs. But
+			// should be reactivated in the coming months.
+//			validateBattery(); 
 
 		}
 

--- a/file_checker_exec/src/test/java/fr/coriolis/checker/e2etests/validateBatteryParamsCheckInMetaFileIT.java
+++ b/file_checker_exec/src/test/java/fr/coriolis/checker/e2etests/validateBatteryParamsCheckInMetaFileIT.java
@@ -44,35 +44,41 @@ class validateBatteryParamsCheckInMetaFileIT {
 
 	}
 
-	@Tag(TEST_DIR_NAME)
-	@ParameterizedTest(name = "{0} from dac {1} should have warning {2}")
-	@CsvSource(delimiter = '|', value = {
-			"5907141_meta_bad-type.nc|coriolis|BATTERY_TYPE[1]: Invalid type: '{BAD}'   *** WILL BECOME AN ERROR ***",
-			"5907141_meta_bad-Manufacturer.nc|coriolis|BATTERY_TYPE[1]: Invalid manufacturer: '{BAD}'   *** WILL BECOME AN ERROR ***",
-			"5907141_meta_incoherent_type.nc|coriolis|Inconsistent battery's type in BATTERY_TYPE[1] and BATTERY_PACKS[1]. BATTERY_TYPE's type ={Lithium}, BATTERY_PACKS's type = {Hyb}",
-			"5907141_meta_incoherent_type_second_pack.nc|coriolis|Inconsistent battery's type in BATTERY_TYPE[2] and BATTERY_PACKS[2]. BATTERY_TYPE's type ={Lithium}, BATTERY_PACKS's type = {Alk}" })
-	void fileChecker_ShouldRaiseWarning_WhenBadBatteryType(String fileName, String dac, String warningMessage)
-			throws IOException, InterruptedException {
-		TestsUtils.e2eTestWarningPresence(fileName, dac, warningMessage, TEST_DIR_NAME);
-	}
+	/*
+	 * 04/26 , v3.0.2 : this e2e tests are deactivated as the Battery checks are
+	 * temporary deactivated. TO DO : The following should be decommented when the
+	 * battery checks are enabled agin in the coming months.
+	 */
 
-	@Tag(TEST_DIR_NAME)
-	@ParameterizedTest(name = "{0} from dac {1} should not have warning")
-	@CsvSource(delimiter = '|', value = { "5907141_meta_good_batteryType.nc|coriolis", })
-	void fileChecker_ShouldNotRaiseWarning_WhenBatteryParamGood(String fileName, String dac)
-			throws IOException, InterruptedException {
-		TestsUtils.e2eTestWarningAbsence(fileName, dac, TEST_DIR_NAME);
-	}
-
-	@Tag(TEST_DIR_NAME)
-	@ParameterizedTest(name = "{0} from dac {1} should have warning {2}")
-	@CsvSource(delimiter = '|', value = {
-			"5907141_meta_BATTERY_PACKS_bad-size.nc|coriolis|BATTERY_PACKS[1]: Invalid style of battery: '{X}'   *** WILL BECOME AN ERROR ***",
-			"5907141_meta_BATTERY_PACKS_bad-type.nc|coriolis|BATTERY_PACKS[1]: Invalid type: '{BAD}'   *** WILL BECOME AN ERROR ***",
-			"5907141_meta_Wrong-number-Battery-Packs.nc|coriolis|Number of BATTERY_TYPES {1} != number of BATTERY_PACKS {2}   *** WILL BECOME AN ERROR ***" })
-	void fileChecker_ShouldRaiseWarning_WhenBadBatteryPacks(String fileName, String dac, String warningMessage)
-			throws IOException, InterruptedException {
-		TestsUtils.e2eTestWarningPresence(fileName, dac, warningMessage, TEST_DIR_NAME);
-	}
+//	@Tag(TEST_DIR_NAME)
+//	@ParameterizedTest(name = "{0} from dac {1} should have warning {2}")
+//	@CsvSource(delimiter = '|', value = {
+//			"5907141_meta_bad-type.nc|coriolis|BATTERY_TYPE[1]: Invalid type: '{BAD}'   *** WILL BECOME AN ERROR ***",
+//			"5907141_meta_bad-Manufacturer.nc|coriolis|BATTERY_TYPE[1]: Invalid manufacturer: '{BAD}'   *** WILL BECOME AN ERROR ***",
+//			"5907141_meta_incoherent_type.nc|coriolis|Inconsistent battery's type in BATTERY_TYPE[1] and BATTERY_PACKS[1]. BATTERY_TYPE's type ={Lithium}, BATTERY_PACKS's type = {Hyb}",
+//			"5907141_meta_incoherent_type_second_pack.nc|coriolis|Inconsistent battery's type in BATTERY_TYPE[2] and BATTERY_PACKS[2]. BATTERY_TYPE's type ={Lithium}, BATTERY_PACKS's type = {Alk}" })
+//	void fileChecker_ShouldRaiseWarning_WhenBadBatteryType(String fileName, String dac, String warningMessage)
+//			throws IOException, InterruptedException {
+//		TestsUtils.e2eTestWarningPresence(fileName, dac, warningMessage, TEST_DIR_NAME);
+//	}
+//
+//	@Tag(TEST_DIR_NAME)
+//	@ParameterizedTest(name = "{0} from dac {1} should not have warning")
+//	@CsvSource(delimiter = '|', value = { "5907141_meta_good_batteryType.nc|coriolis", })
+//	void fileChecker_ShouldNotRaiseWarning_WhenBatteryParamGood(String fileName, String dac)
+//			throws IOException, InterruptedException {
+//		TestsUtils.e2eTestWarningAbsence(fileName, dac, TEST_DIR_NAME);
+//	}
+//
+//	@Tag(TEST_DIR_NAME)
+//	@ParameterizedTest(name = "{0} from dac {1} should have warning {2}")
+//	@CsvSource(delimiter = '|', value = {
+//			"5907141_meta_BATTERY_PACKS_bad-size.nc|coriolis|BATTERY_PACKS[1]: Invalid style of battery: '{X}'   *** WILL BECOME AN ERROR ***",
+//			"5907141_meta_BATTERY_PACKS_bad-type.nc|coriolis|BATTERY_PACKS[1]: Invalid type: '{BAD}'   *** WILL BECOME AN ERROR ***",
+//			"5907141_meta_Wrong-number-Battery-Packs.nc|coriolis|Number of BATTERY_TYPES {1} != number of BATTERY_PACKS {2}   *** WILL BECOME AN ERROR ***" })
+//	void fileChecker_ShouldRaiseWarning_WhenBadBatteryPacks(String fileName, String dac, String warningMessage)
+//			throws IOException, InterruptedException {
+//		TestsUtils.e2eTestWarningPresence(fileName, dac, warningMessage, TEST_DIR_NAME);
+//	}
 
 }

--- a/file_checker_spec/NVS/R01.jsonld
+++ b/file_checker_spec/NVS/R01.jsonld
@@ -269,7 +269,7 @@
             "dce:identifier": "SDN:R01::METAAUX",
             "pav:version": "1",
             "skos:notation": "SDN:R01::METAAUX",
-            "skos:altLabel": "",
+            "skos:altLabel": "METAAUX",
             "dc:date": "2024-09-11 11:40:41.0",
             "owl:versionInfo": "1",
             "skos:prefLabel": {

--- a/file_checker_spec/NVS/R08.jsonld
+++ b/file_checker_spec/NVS/R08.jsonld
@@ -684,9 +684,14 @@
             "dc:date": "2023-10-05 14:39:49.0",
             "skos:altLabel": "836",
             "skos:notation": "SDN:R08::836",
-            "skos:broader": {
-                "@id": "http://vocab.nerc.ac.uk/collection/R23/current/PROVOR_III/"
-            },
+			"skos:broader": [
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R23/current/PROVOR_III/"
+                },
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R23/current/PROVOR_III_JUMBO/"
+                }
+            ],
             "pav:version": "2",
             "dce:identifier": "SDN:R08::836",
             "pav:hasCurrentVersion": {
@@ -702,9 +707,14 @@
             },
             "dce:identifier": "SDN:R08::843",
             "pav:version": "1",
-            "skos:broader": {
-                "@id": "http://vocab.nerc.ac.uk/collection/R23/current/POPS_PROVOR/"
-            },
+			"skos:broader": [
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R23/current/POPS_PROVOR/"
+                },
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R23/current/POPS_NEMO/"
+                }
+            ],
             "skos:notation": "SDN:R08::843",
             "skos:altLabel": "843",
             "dc:date": "2020-05-03 20:28:54.0",

--- a/file_checker_spec/NVS/R23.jsonld
+++ b/file_checker_spec/NVS/R23.jsonld
@@ -100,6 +100,9 @@
             "skos:related": {
                 "@id": "http://vocab.nerc.ac.uk/collection/R24/current/OPTIMARE/"
             },
+			"skos:narrower": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R08/current/843/"
+            },
             "@type": "skos:Concept"
         },
         {
@@ -111,7 +114,7 @@
             "dce:identifier": "SDN:R23::PROVOR_III_JUMBO",
             "pav:version": "1",
             "skos:notation": "SDN:R23::PROVOR_III_JUMBO",
-            "skos:altLabel": "",
+            "skos:altLabel": "PROVOR_III_JUMBO",
             "dc:date": "2024-09-11 11:40:41.0",
             "owl:versionInfo": "1",
             "skos:prefLabel": {
@@ -130,6 +133,12 @@
             "skos:definition": {
                 "@language": "en",
                 "@value": "PROVOR float with additional battery pack. PLATFORM_ TYPE_ KEY = 108."
+            },
+			"skos:related": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R24/current/NKE/"
+            },
+			"skos:narrower": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R08/current/836/"
             },
             "@type": "skos:Concept"
         },

--- a/file_checker_spec/NVS/R25.jsonld
+++ b/file_checker_spec/NVS/R25.jsonld
@@ -83,7 +83,7 @@
             },
             "owl:versionInfo": "1",
             "dc:date": "2023-11-24 09:35:13.0",
-            "skos:altLabel": ""
+            "skos:altLabel": "CTD_TEMP_CNDC"
         },
         {
             "@id": "http://vocab.nerc.ac.uk/collection/R25/current/FLUOROMETER_CHLA/",
@@ -1059,7 +1059,11 @@
                 },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/RAMSES_ACC/"
+                },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/OCR504_ICSW/"
                 }
+				
             ],
             "skos:definition": {
                 "@language": "en",

--- a/file_checker_spec/NVS/R26.jsonld
+++ b/file_checker_spec/NVS/R26.jsonld
@@ -1102,6 +1102,9 @@
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.4/"
                 },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.5/"
+                },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41CP_V1.2/"
                 },

--- a/file_checker_spec/NVS/R26.jsonld
+++ b/file_checker_spec/NVS/R26.jsonld
@@ -864,6 +864,9 @@
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/RBR_PRES/"
                 },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/RBR_CTD/"
+                },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/RBR_ARGO/"
                 },
@@ -1165,6 +1168,9 @@
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE63_OPTODE/"
                 },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE83_OPTODE/"
+                },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41CP_V1/"
                 },
@@ -1273,6 +1279,9 @@
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SATLANTIC_OCR504_ICSW/"
                 },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/OCR504_ICSW/"
+                },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41CP_V1.9/"
                 },
@@ -1299,6 +1308,9 @@
                 },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SATLANTIC_OCR504_R10W/"
+                },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/OCR504_R10W/"
                 },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/C_ROVER/"

--- a/file_checker_spec/NVS/R27.jsonld
+++ b/file_checker_spec/NVS/R27.jsonld
@@ -95,6 +95,9 @@
             "dc:date": "2025-11-18 12:09:41.0",
             "skos:altLabel": "SBE83_OPTODE",
             "skos:notation": "SDN:R27::SBE83_OPTODE",
+			"skos:broader": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R26/current/SBE/"
+            },			
             "pav:version": "2",
             "dce:identifier": "SDN:R27::SBE83_OPTODE",
             "pav:hasCurrentVersion": {
@@ -124,6 +127,9 @@
                     "@id": "http://vocab.nerc.ac.uk/collection/R25/current/CTD_TEMP_CNDC/"
                 }
             ],
+			"skos:broader": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R26/current/RBR/"
+            },
             "skos:definition": {
                 "@language": "en",
                 "@value": "A system comprising temperature, conductivity and pressure sensors, manufactured by RBR for moored applications. This cell was not optimized for use on profiling floats, and this was used in only one test deployment. The system supports both spot and continuous sampling modes, with sampling speeds configurable to up to 12 Hz. The depth rating for a standard profile is 2000 dbar, with energy consumption of approximately 700 J."
@@ -169,6 +175,9 @@
                     "@id": "http://vocab.nerc.ac.uk/collection/R25/current/RADIOMETER_UP_RAD412/"
                 }
             ],
+			"skos:broader": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R26/current/SBE/"
+            },
             "skos:definition": {
                 "@language": "en",
                 "@value": "Replaces deprecated term  'http://vocab.nerc.ac.uk/collection/R27/current/SATLANTIC_OCR504_R10W'. A cosine-response, multispectral radiometer configured to measure upwelling radiance in water. Number of channels: 4; field of view: 10 deg (half angle, half maximum); bandwidth range: 400 nm to 865 nm (standard), or 305 nm, 325 nm, 340 nm, 380 nm (UV); sampling rate: 7 Hz - 24 Hz; spectral bandwidth: 10 nm or 20 nm. The instrument was originally developed and manufactured at Satlantic, and was rebranded as a Sea-Bird Scientific product following the company's acquisition by Danaher in 2011."
@@ -216,8 +225,14 @@
                 },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R25/current/RADIOMETER_DOWN_IRR490/"
-                }
+                },
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R25/current/RADIOMETER_PAR/"
+                }				
             ],
+			"skos:broader": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R26/current/SBE/"
+            },
             "skos:definition": {
                 "@language": "en",
                 "@value": "Replaces deprecated term  'http://vocab.nerc.ac.uk/collection/R27/current/SATLANTIC_OCR504_ICSW'. A cosine-response, multispectral radiometer configured to measure downwelling irradiance in water. Number of channels: 4; bandwidth range: 400 nm to 865 nm (standard), or 305 nm, 325 nm, 340 nm, 380 nm (UV); sampling rate: 7 Hz - 24 Hz; spectral bandwidth: 10 nm or 20 nm. The instrument was originally developed and manufactured at Satlantic, and was rebranded as a Sea-Bird Scientific product following the company's acquisition by Danaher in 2011."

--- a/file_checker_spec/NVS/R27.jsonld
+++ b/file_checker_spec/NVS/R27.jsonld
@@ -2685,6 +2685,57 @@
                 "@id": "http://vocab.nerc.ac.uk/collection/R26/current/SBE/"
             }
         },
+		{
+            "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.5/",
+            "pav:hasVersion": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.5/1/"
+            },
+            "pav:authoredOn": "2025-04-03 11:54:30.0",
+            "pav:hasCurrentVersion": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.5/2/"
+            },
+            "dce:identifier": "SDN:R27::SBE41N_V5.3.5",
+            "pav:version": "2",
+            "@type": "skos:Concept",
+            "skos:related": [
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N/"
+                },
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R25/current/CTD_PRES/"
+                },
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R25/current/CTD_TEMP/"
+                },
+                {
+                    "@id": "http://vocab.nerc.ac.uk/collection/R25/current/CTD_CNDC/"
+                }
+            ],
+            "skos:definition": {
+                "@language": "en",
+                "@value": "A system comprising temperature, conductivity and pressure sensors with pump-controlled, T-C ducted flow, manufactured by Sea-Bir Scientific. The unit is designed for deployment on profiling floats hosting multiple biogeochemical (BGC) sensors. This CTD operates in continuous profiling (CP) mode, thus sampling at 1 Hz during float ascent. Data from all the float's sensors, including the optional bolt-on ones, are integrated in the data stream and transmitted to the float controller when the float reaches the surface. This SBE41N model has firmware version 5.3.5."
+            },
+            "void:inDataset": {
+                "@id": "http://vocab.nerc.ac.uk/.well-known/void"
+            },
+            "owl:deprecated": "true",
+            "skos:note": {
+                "@language": "en",
+                "@value": "deprecated"
+            },
+            "dc:identifier": "SDN:R27::SBE41N_V5.3.5",
+            "skos:prefLabel": {
+                "@language": "en",
+                "@value": "Sea-Bird Scientific SBE 41N CTD V5.3.5"
+            },
+            "owl:versionInfo": "2",
+            "dc:date": "2025-04-03 11:54:30.0",
+            "skos:altLabel": "SBE41N_V5.3.5",
+            "skos:notation": "SDN:R27::SBE41N_V5.3.5",
+            "skos:broader": {
+                "@id": "http://vocab.nerc.ac.uk/collection/R26/current/SBE/"
+            }
+        },
         {
             "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N/",
             "pav:hasVersion": {
@@ -6699,6 +6750,9 @@
                 },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.4/"
+                },
+				{
+                    "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41N_V5.3.5/"
                 },
                 {
                     "@id": "http://vocab.nerc.ac.uk/collection/R27/current/SBE41CP_V1.2/"

--- a/file_checker_spec/NVS/dateOfUpdate.txt
+++ b/file_checker_spec/NVS/dateOfUpdate.txt
@@ -1,1 +1,2 @@
 2026-04-21T09:24:48.256314
+manual fixes done on R01, R08, R23, R25, R27


### PR DESCRIPTION
- Add missing entries/mappings in some exported NVS tables wich was causing files rejects (https://github.com/OneArgo/ArgoFormatChecker/issues/47 and https://github.com/OneArgo/ArgoFormatChecker/issues/48)
- Fix issue when deprecated entry is found in R14 or R18 but a valid entry with a template <short_sensor_name> also exist (https://github.com/OneArgo/ArgoFormatChecker/issues/49)
- Deactivate Battery Parameters checks as most files are not compliant and too much warnings was issued. Will give  more time to DACs to modify the files.


